### PR TITLE
Enable item searching from frontend

### DIFF
--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -758,13 +758,15 @@ func (h *Handler) SearchItemByKeyword(c echo.Context) error {
 	keyword := c.QueryParam("name")
 	if keyword == "" {
 		// Keyword is required
+		c.Logger().Error("Keyword is required")
 		return echo.NewHTTPError(http.StatusBadRequest, "Keyword is required")
 	}
 
 	// Call your repository method
 	items, err := h.ItemRepo.GetItemByKeyword(ctx, keyword)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	    c.Logger().Error(err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "Internal server error")
 	}
 
 	// return the response
@@ -772,7 +774,8 @@ func (h *Handler) SearchItemByKeyword(c echo.Context) error {
 	for _, item := range items {
 		cats, err := h.ItemRepo.GetCategories(ctx)
 		if err != nil {
-			return c.JSON(http.StatusInternalServerError, err)
+		    c.Logger().Error(err)
+			return c.JSON(http.StatusInternalServerError, "Internal server error")
 		}
 		for _, cat := range cats {
 			if cat.ID == item.CategoryID {

--- a/frontend/simple-mercari-web/src/App.tsx
+++ b/frontend/simple-mercari-web/src/App.tsx
@@ -10,6 +10,7 @@ import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { ThemeProvider } from '@mui/material/styles';
 import theme from './theme';
+import { Search } from "./components/Search";
 
 export const App: React.VFC = () => {
   return (
@@ -23,6 +24,7 @@ export const App: React.VFC = () => {
             <Route index element={<Home />} />
             <Route path="/item/:id" element={<ItemDetail />} />
             <Route path="/user/:id" element={<UserProfile />} />
+            <Route path="/search" element={<Search />} />
             <Route path="/sell" element={<Listing />} />
             <Route path="/edit-item/:itemId" element={<Listing />} />
           </Routes>

--- a/frontend/simple-mercari-web/src/components/Header/Header.css
+++ b/frontend/simple-mercari-web/src/components/Header/Header.css
@@ -1,7 +1,7 @@
 header {
   display: flex;
   flex-direction: row;
-  margin: 1.5em;
+  margin: 1em;
 }
 
 .LogoutButtonContainer {
@@ -11,7 +11,7 @@ header {
   width: 100px;
 }
 .logo{
-  width: 7em;
+  width: 6em;
   aspect-ratio: 7/3.5;
   padding-left: 5em;
 }

--- a/frontend/simple-mercari-web/src/components/Header/Header.css
+++ b/frontend/simple-mercari-web/src/components/Header/Header.css
@@ -1,7 +1,7 @@
 header {
   display: flex;
   flex-direction: row;
-  margin: 1em;
+  margin: 0.5em;
 }
 
 .LogoutButtonContainer {

--- a/frontend/simple-mercari-web/src/components/Header/Header.tsx
+++ b/frontend/simple-mercari-web/src/components/Header/Header.tsx
@@ -45,9 +45,15 @@ export const Header: React.FC = () => {
             // vertical padding + font size from searchIcon
             paddingLeft: `calc(1em + ${theme.spacing(4)})`,
             transition: theme.transitions.create('width'),
-            width: '100%',
-            [theme.breakpoints.up('md')]: {
-                width: '35ch',
+            width: '35ch',
+            [theme.breakpoints.down('md')]: {
+                width: '23ch',
+            },
+            [theme.breakpoints.down('sm')]: {
+                width: '10ch',
+                '&::placeholder': {
+                    textOverflow: 'ellipsis !important',
+                }
             },
         },
     }));

--- a/frontend/simple-mercari-web/src/components/Header/Header.tsx
+++ b/frontend/simple-mercari-web/src/components/Header/Header.tsx
@@ -1,17 +1,76 @@
 
 import "./Header.css";
 import logo from '../assets/logo.png'
-
+import * as React from 'react';
+import { styled, alpha } from '@mui/material/styles'
+import InputBase from '@mui/material/InputBase';
+import SearchIcon from '@mui/icons-material/Search';
+import {Toolbar} from "@mui/material";
+import {useCookies} from "react-cookie";
 
 export const Header: React.FC = () => {
+    const [cookies] = useCookies(["userID", "token"]);
 
+    const Search = styled('div')(({ theme }) => ({
+        position: 'relative',
+        borderRadius: theme.shape.borderRadius,
+        backgroundColor: alpha(theme.palette.grey["300"], 0.15),
+        border: '1px solid' + theme.palette.grey["300"],
+        '&:hover': {
+            border: '1px solid' + theme.palette.grey["400"],
+        },
+        marginRight: theme.spacing(2),
+        marginLeft: 0,
+        width: '100%',
+        [theme.breakpoints.up('sm')]: {
+            marginLeft: theme.spacing(2),
+            width: 'auto',
+        },
+    }));
+
+    const SearchIconWrapper = styled('div')(({ theme }) => ({
+        padding: theme.spacing(0, 2),
+        height: '100%',
+        position: 'absolute',
+        pointerEvents: 'none',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+    }));
+
+    const StyledInputBase = styled(InputBase)(({ theme }) => ({
+        color: 'inherit',
+        '& .MuiInputBase-input': {
+            padding: theme.spacing(1, 1, 1, 0),
+            // vertical padding + font size from searchIcon
+            paddingLeft: `calc(1em + ${theme.spacing(4)})`,
+            transition: theme.transitions.create('width'),
+            width: '100%',
+            [theme.breakpoints.up('md')]: {
+                width: '35ch',
+            },
+        },
+    }));
 
   return (
     <>
       <header>
-        <div>
-          <img className="logo" src={logo} alt="logo" />
-        </div>
+          <Toolbar>
+              <div>
+                  <img className="logo" src={logo} alt="logo" />
+              </div>
+              {cookies.token &&
+                  <Search>
+                      <SearchIconWrapper>
+                          <SearchIcon />
+                      </SearchIconWrapper>
+                      <StyledInputBase
+                          placeholder="Shop one-of-a-kind finds"
+                          inputProps={{ 'aria-label': 'search' }}
+                      />
+                  </Search>
+              }
+          </Toolbar>
       </header>
     </>
   );

--- a/frontend/simple-mercari-web/src/components/Header/Header.tsx
+++ b/frontend/simple-mercari-web/src/components/Header/Header.tsx
@@ -7,9 +7,11 @@ import InputBase from '@mui/material/InputBase';
 import SearchIcon from '@mui/icons-material/Search';
 import {Toolbar} from "@mui/material";
 import {useCookies} from "react-cookie";
+import {useNavigate} from "react-router-dom";
 
 export const Header: React.FC = () => {
     const [cookies] = useCookies(["userID", "token"]);
+    const navigate = useNavigate();
 
     const Search = styled('div')(({ theme }) => ({
         position: 'relative',
@@ -58,6 +60,20 @@ export const Header: React.FC = () => {
         },
     }));
 
+    const handleSubmit = (
+        e: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLInputElement>, search: string
+    ) => {
+        e.preventDefault();
+        navigate(`/search?keyword=${search}`);
+        window.location.reload();
+    }
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.nativeEvent.isComposing || e.key !== 'Enter') return
+        const search = e.currentTarget.value;
+        handleSubmit(e, search)
+    }
+
   return (
     <>
       <header>
@@ -73,6 +89,9 @@ export const Header: React.FC = () => {
                       <StyledInputBase
                           placeholder="Shop one-of-a-kind finds"
                           inputProps={{ 'aria-label': 'search' }}
+                          onKeyDown={handleKeyDown}
+                          // TODO: Display suggestions when user types
+                          // onChange={onChangeSuggestion}
                       />
                   </Search>
               }

--- a/frontend/simple-mercari-web/src/components/Search/Search.tsx
+++ b/frontend/simple-mercari-web/src/components/Search/Search.tsx
@@ -1,0 +1,62 @@
+import {MerComponent} from "../MerComponent";
+import {ItemList} from "../ItemList";
+import React from "react";
+import {Item} from "../../common/interfaces";
+import {fetcher} from "../../helper";
+import {useEffect, useState} from "react";
+import "./search.css"
+import { Typography } from '@mui/material';
+import theme from "../../theme";
+
+export const Search = () => {
+    const [items, setItems] = useState<Item[]>([]);
+    const [keyword, setKeyword] = useState<string>("");
+    const query = new URLSearchParams(window.location.search);
+
+    console.log("keyword", keyword)
+    const fetchItems = () => {
+        fetcher<Item[]>(`/search?name=` + keyword , {
+            method: "GET",
+            headers: {
+                Accept: "application/json",
+                "Content-Type": "application/json",
+            },
+        })
+            .then((res) => {
+                console.log("GET success:", res);
+                setItems(res);
+            })
+
+            .catch((err) => {
+                console.log(`GET error:`, err);
+            });
+    }
+
+    useEffect(() => {
+        console.log("fetching items");
+        fetchItems();
+    }, [keyword]);
+
+    useEffect(() => {
+        setKeyword(query.get("keyword") || "");
+    }, []);
+
+    return (
+        <MerComponent>
+            <div className={"search-container"}>
+                <div className={"search-title"}>
+                    <Typography variant="h4" component="p" color={theme.palette.common.black}>
+                        {/* TODO: Display some message when the query is empty */}
+                        {keyword ? `Search results for "${keyword}"` : ""}
+                        <span> </span>
+                        <Typography variant="h6" component="span" color={theme.palette.grey["600"]}>
+                            ({items?.length ?? 0} results)
+                        </Typography>
+                    </Typography>
+                </div>
+                {/* TODO: Distinguish items that are sold out and still for sale */}
+                <ItemList items={items} />
+            </div>
+        </MerComponent>
+    )
+}

--- a/frontend/simple-mercari-web/src/components/Search/index.tsx
+++ b/frontend/simple-mercari-web/src/components/Search/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Search";

--- a/frontend/simple-mercari-web/src/components/Search/search.css
+++ b/frontend/simple-mercari-web/src/components/Search/search.css
@@ -1,0 +1,8 @@
+.search-container {
+    width: 100%;
+    max-width: 80%;
+    overflow: hidden;
+    margin: 50px auto;
+    display: flex;
+    flex-direction: column;
+}


### PR DESCRIPTION
## Goal
Enable users to search items by keyword

## Changes 
1. Added a search bar on top
2. User can type in the search bar and search items

## Demo
https://github.com/xu-jiach/mercari-build-hackathon-2023/assets/90857923/d41727ca-5ac6-419e-b51d-f3672bcb1d79

## Note
There's a couple of extra features I want to add:
- Search recommendation
- Distinguish items that are sold out from ones still on sale

