### PR TITLE
ui for new in person purchases feature

### DIFF
--- a/frontend/simple-mercari-web/src/components/ItemDetail/ItemDescription.tsx
+++ b/frontend/simple-mercari-web/src/components/ItemDetail/ItemDescription.tsx
@@ -1,13 +1,17 @@
 import { Item, ItemStatus } from "../../common/interfaces";
 import { useNavigate, useParams } from "react-router-dom";
-import React from "react";
+import React, { useEffect, useState, ReactNode, ChangeEvent} from "react";
 import { useCookies } from "react-cookie";
 import { fetcher } from "../../helper";
 import { toast } from "react-toastify";
 import Button from "@mui/material/Button";
-import { Chip } from "@mui/material";
+import { Chip, TextField, FormControlLabel, Checkbox } from "@mui/material";
+
+
 
 export const ItemDescription: React.FC<{ item: Item, isOwner: boolean}>  = ({item, isOwner}) => {
+    const [imWithSeller, setImWithSeller] = useState(false);
+
     const navigate = useNavigate();
     const [cookies] = useCookies(["token", "userID"]);
     const params = useParams();
@@ -44,16 +48,49 @@ export const ItemDescription: React.FC<{ item: Item, isOwner: boolean}>  = ({ite
             ) : (
                 <>
                     {isOwner && (
+                      <>
                         <Button
                             onClick={() => navigate(`/edit-item/${item.id}`)} // Navigate to /edit-item/:itemId when the Edit button is clicked
                             id="MerButton"
                         >
                             Edit
                         </Button>
+                        {/* {inPersonPasscode &&(
+                          <p><strong>In person purchasing with passcode: #VW-4869</strong></p>
+                        )} */}
+                        <p><strong>In person purchasing with passcode: #VW-4869</strong></p>
+                      </>
                     )}
-                    <Button variant="contained" onClick={onSubmit} id="buy-now-btn" color="error" sx={{ mt: 3}}>
-                        Buy now
-                    </Button>
+                    <hr/>
+                    {!isOwner && (
+                      <>
+                        <Button variant="contained" onClick={onSubmit} id="buy-now-btn" color="primary" sx={{ mt: 3}}>
+                          Buy now
+                        </Button>
+                        {/**Also check here if in person passcode is enabled */}
+                        <FormControlLabel sx={{ mt: 3 }}
+                          control={
+                            <Checkbox
+                              checked={imWithSeller}
+                              onChange={(event) => setImWithSeller(event.target.checked)}
+                            />
+                          }
+                          label="I'm with the owner"
+                        />
+                        <TextField sx={{ mt: 2, ml: 3 }}
+                          id="inPersonKey"
+                          name="inPersonKey"
+                          //value={values.inPersonKey}
+                          //onChange={onValueChange}
+                          label="In Person Passcode"
+                          disabled={!imWithSeller}
+                        />
+                      </>
+                    )}
+
+
+
+
                 </>
             )}
 

--- a/frontend/simple-mercari-web/src/components/Listing/Listing.tsx
+++ b/frontend/simple-mercari-web/src/components/Listing/Listing.tsx
@@ -5,6 +5,7 @@ import { MerComponent } from "../MerComponent";
 import { toast } from "react-toastify";
 import { fetcher } from "../../helper";
 import { Button, TextField, FormControl, InputLabel, Select, MenuItem, Checkbox, FormControlLabel, SelectChangeEvent } from '@mui/material';
+import Tooltip, { TooltipProps, tooltipClasses } from '@mui/material/Tooltip';
 
 
 interface Category {
@@ -42,6 +43,7 @@ export const Listing: React.FC = () => {
   const [fileName, setFileName] = useState("");
   const isEditing = itemId !== undefined;
   const navigate = useNavigate();
+  const inPersonDescription = "Passcode required, only share with in person buyer"
 
 
   const onValueChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -243,10 +245,14 @@ export const Listing: React.FC = () => {
     }
   }, [newCategory, categories]);
 
+  const [allowInPersonPurchases, setAllowInPersonPurchases] = useState(false);
+
+
 
   return(
     <MerComponent>
       <div className="Listing">
+        <h1>List a new item</h1>
         <form onSubmit={onSubmit}>
           <div className="listing-form">
               <TextField
@@ -256,7 +262,7 @@ export const Listing: React.FC = () => {
                 onChange={onValueChange}
                 label="Name"
                 required
-                sx={{ mb: 3}}
+                sx={{ mt: 3, mb: 3}}
               />
               <FormControl>
                 <InputLabel id="category-label">Category</InputLabel>
@@ -268,14 +274,14 @@ export const Listing: React.FC = () => {
                   onChange={onSelectChange}
                   sx={{ mt: 3 }}
                 >
-                  <MenuItem value={0} disabled>Select a category</MenuItem> {/* Placeholder item */}
+                  <MenuItem value={0} disabled>Select a category</MenuItem>
                   {categories &&
                     categories.map((category) => {
                       return <MenuItem value={category.id}>{category.name}</MenuItem>;
                     })}
                 </Select>
               </FormControl>
-              <FormControlLabel
+              <FormControlLabel sx={{ mt: 3 }}
                 control={
                   <Checkbox
                     checked={newCategoryCheckboxChecked}
@@ -342,6 +348,28 @@ export const Listing: React.FC = () => {
                 />
               </Button>
               {fileName && <div className="mt1">Selected file: {fileName}</div>}
+
+              <Tooltip title={inPersonDescription} arrow>
+                <FormControlLabel sx={{ mt: 3 }}
+                  control={
+                    <Checkbox
+                      checked={allowInPersonPurchases}
+                      onChange={(event) => setAllowInPersonPurchases(event.target.checked)}
+                    />
+                  }
+                  label="Allow in person purchases"
+                />
+              </Tooltip>
+              <TextField
+                id="inPersonKey"
+                name="inPersonKey"
+                //value={values.inPersonKey}
+                onChange={onValueChange}
+                label="In Person Passcode"
+                sx={{ mt: 3 }}
+                disabled={!allowInPersonPurchases}
+              />
+
               <Button variant="contained" type="submit" color="secondary" sx={{ mt: 3 }}>
                 List
               </Button>


### PR DESCRIPTION
Front end for add new person ui

- Updated Listing page with a allow in person purchases check box and code entry
- Updated Item Description to show the code you are the owner and in person purchasing is enabled
- Fixed error where you could buy your own item
- If you want to buy an item in person you can now see the option (probably need to link the buy now button with this button if the passcode is correct)

Backend is necessary to complete these features, but here is the demo: 



https://github.com/xu-jiach/mercari-build-hackathon-2023/assets/74501096/5ac11b91-0677-4e33-9c9f-6a31c1d20f11


