### PR TITLE
Let the backend and frontend communicate with each other about in-person purchase

### DIFF
--- a/backend/db/repository.go
+++ b/backend/db/repository.go
@@ -282,6 +282,7 @@ func (r *ItemDBRepository) GetItemsByCategory(ctx context.Context, categoryID in
 type OnsitePurchaseRepository interface {
 	AddOnsitePurchase(ctx context.Context, purchase domain.OnsitePurchase) error
 	ValidatePassword(ctx context.Context, itemID int64, password string) (bool, error)
+	GetItemPassword(ctx context.Context, userID int64, itemID int32) (string, error)
 }
 
 type OnsitePurchaseDBRepository struct {
@@ -322,4 +323,15 @@ func (r *OnsitePurchaseDBRepository) ValidatePassword(ctx context.Context, itemI
 	} else {
 		return false, nil
 	}
+}
+
+func (r *OnsitePurchaseDBRepository) GetItemPassword(ctx context.Context, userID int64, itemID int32) (string, error) {
+	row := r.QueryRowContext(ctx, "SELECT password FROM onsite_purchase WHERE item_id = ? AND seller_id = ?", itemID, userID)
+
+	var password string
+	if err := row.Scan(&password); err != nil {
+		return "", err
+	}
+
+	return password, nil
 }

--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -71,6 +71,10 @@ type getItemResponse struct {
 	Status       domain.ItemStatus `json:"status"`
 }
 
+type getItemPasswordResponse struct {
+	Password string `json:"password"`
+}
+
 type getCategoriesResponse struct {
 	ID   int64  `json:"id"`
 	Name string `json:"name"`
@@ -627,6 +631,27 @@ func (h *Handler) GetItem(c echo.Context) error {
 		Description:  item.Description,
 		Status:       item.Status,
 	})
+}
+
+// GetItemPassword returns item password.
+// It is separeted from GetItem not to affect benchmark.
+func (h *Handler) GetItemPassword(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	itemID, err := strconv.ParseInt(c.Param("itemID"), 10, 64)
+
+	userID, err := getUserID(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid user")
+	}
+
+	pass, err := h.OnsitePurchaseRepo.GetItemPassword(ctx, userID, int32(itemID))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error")
+	}
+
+	return c.JSON(http.StatusOK, getItemPasswordResponse{Password: pass})
+
 }
 
 func (h *Handler) GetUserItems(c echo.Context) error {

--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -85,10 +85,11 @@ type sellRequest struct {
 }
 
 type addItemRequest struct {
-	Name        string `form:"name"`
-	CategoryID  int64  `form:"category_id"`
-	Price       int64  `form:"price"`
-	Description string `form:"description"`
+	Name         string `form:"name"`
+	CategoryID   int64  `form:"category_id"`
+	Price        int64  `form:"price"`
+	Description  string `form:"description"`
+	ItemPassword string `form:"item_password"`
 }
 
 type addItemResponse struct {
@@ -384,6 +385,15 @@ func (h *Handler) AddItem(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 
+	err = h.OnsitePurchaseRepo.AddOnsitePurchase(ctx, domain.OnsitePurchase{
+		ItemID:   item.ID,
+		SellerID: userID,
+		Password: req.ItemPassword,
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err)
+	}
+
 	return c.JSON(http.StatusOK, addItemResponse{ID: int64(item.ID)})
 }
 
@@ -647,6 +657,7 @@ func (h *Handler) GetItemPassword(c echo.Context) error {
 
 	pass, err := h.OnsitePurchaseRepo.GetItemPassword(ctx, userID, int32(itemID))
 	if err != nil {
+		c.Logger().Printf("failed to get item password: %v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error")
 	}
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -95,6 +95,7 @@ func run(ctx context.Context) int {
 	l.Use(echojwt.WithConfig(config))
 	l.GET("/users/:userID/items", h.GetUserItems)
 	l.POST("/items", h.AddItem)
+	l.POST("/items/:itemID/pass", h.GetItemPassword)
 	l.PUT("/items/:itemID", h.EditItem)
 	l.POST("/sell", h.Sell)
 	l.POST("/purchase/:itemID", h.Purchase)

--- a/frontend/simple-mercari-web/src/components/ItemDetail/ItemDescription.tsx
+++ b/frontend/simple-mercari-web/src/components/ItemDetail/ItemDescription.tsx
@@ -7,10 +7,13 @@ import { toast } from "react-toastify";
 import Button from "@mui/material/Button";
 import { Chip, TextField, FormControlLabel, Checkbox } from "@mui/material";
 
-
+type InPersonPasscode = {
+    password: string;
+}
 
 export const ItemDescription: React.FC<{ item: Item, isOwner: boolean}>  = ({item, isOwner}) => {
     const [imWithSeller, setImWithSeller] = useState(false);
+    const [inPersonPasscode, setInPersonPasscode] = useState<string | null>(null);
 
     const navigate = useNavigate();
     const [cookies] = useCookies(["token", "userID"]);
@@ -35,6 +38,30 @@ export const ItemDescription: React.FC<{ item: Item, isOwner: boolean}>  = ({ite
             });
     };
 
+    const getInPersonPasscode = () => {
+        fetcher<InPersonPasscode>(`/items/${params.id}/pass`, {
+            method: "POST",
+            headers: {
+                Accept: "application/json",
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${cookies.token}`,
+            },
+        })
+            .then((res) => {
+                console.log(`GET response:`, res);
+                setInPersonPasscode(res.password);
+            })
+            .catch((err) => {
+                console.log(`GET error:`, err);
+            });
+    }
+
+    useEffect(() => {
+        if (isOwner) {
+            getInPersonPasscode();
+        }
+    }, []);
+
     return (
         <div className={"description-container"}>
             <h1>{item.name}</h1>
@@ -55,10 +82,9 @@ export const ItemDescription: React.FC<{ item: Item, isOwner: boolean}>  = ({ite
                         >
                             Edit
                         </Button>
-                        {/* {inPersonPasscode &&(
-                          <p><strong>In person purchasing with passcode: #VW-4869</strong></p>
-                        )} */}
-                        <p><strong>In person purchasing with passcode: #VW-4869</strong></p>
+                         {inPersonPasscode &&(
+                          <p><strong>In person purchasing with passcode: {inPersonPasscode}</strong></p>
+                        )}
                       </>
                     )}
                     <hr/>

--- a/frontend/simple-mercari-web/src/components/Listing/Listing.tsx
+++ b/frontend/simple-mercari-web/src/components/Listing/Listing.tsx
@@ -20,6 +20,7 @@ type formDataType = {
   price: number;
   description: string;
   image: string | File;
+  item_passcode: string;
 };
 
 export const Listing: React.FC = () => {
@@ -30,6 +31,7 @@ export const Listing: React.FC = () => {
     price: 0,
     description: "",
     image: "",
+    item_passcode: "",
   };
   const [values, setValues] = useState<formDataType>(initialState);
   const [categories, setCategories] = useState<Category[]>([]);
@@ -104,6 +106,7 @@ export const Listing: React.FC = () => {
     data.append("price", values.price.toString());
     data.append("description", values.description);
     data.append("image", values.image);
+    data.append("item_password", values.item_passcode);
 
   // If category_id is 0, create a new category and get its id
     if (values.category_id === 0) {
@@ -361,15 +364,14 @@ export const Listing: React.FC = () => {
                 />
               </Tooltip>
               <TextField
-                id="inPersonKey"
-                name="inPersonKey"
-                //value={values.inPersonKey}
+                id="item_passcode"
+                name="item_passcode"
+                value={values.item_passcode}
                 onChange={onValueChange}
                 label="In Person Passcode"
                 sx={{ mt: 3 }}
                 disabled={!allowInPersonPurchases}
               />
-
               <Button variant="contained" type="submit" color="secondary" sx={{ mt: 3 }}>
                 List
               </Button>


### PR DESCRIPTION
## Demo
- Sellers can set password for in-person purchase
- They can see the password if it's available for in-person purchase
- They cannot see password for other's items

https://github.com/xu-jiach/mercari-build-hackathon-2023/assets/90857923/3a493599-a659-4baa-867e-c91a9cdc78f1

## TODO
- Enable the edit item `PUT /items/:itemID` endpoint for item password